### PR TITLE
GQL2-22 Custom Render for tests

### DIFF
--- a/src/__tests__/userReducer.test.ts
+++ b/src/__tests__/userReducer.test.ts
@@ -1,0 +1,27 @@
+import reducer, { setUser } from '@/store/reducers/userSlice';
+import { User } from '@/types/user';
+import { UserState } from '@/store/reducers/userSlice';
+
+const user: User = {
+  email: 'some@email.co',
+  id: 'some_id',
+};
+
+const nullState: UserState = {
+  user: null,
+};
+
+const someState: UserState = {
+  user,
+};
+
+describe('userReducer should work correctly and:', () => {
+  it('should return the initial state with undefined', () => {
+    expect(reducer(undefined, { type: undefined })).toEqual(nullState);
+  });
+
+  it('setUser should work correctly', () => {
+    expect(reducer(nullState, setUser(user))).toEqual(someState);
+    expect(reducer(someState, setUser(null))).toEqual(nullState);
+  });
+});

--- a/src/components/Footer/Footer.test.tsx
+++ b/src/components/Footer/Footer.test.tsx
@@ -1,0 +1,31 @@
+import { customRender } from '@/test/providers/customRender';
+import Footer from '@/components/Footer/Footer';
+
+describe('Footer should render correctly', () => {
+  it('should render all elements', () => {
+    const { getByText, getAllByRole, getAllByTestId } = customRender(
+      <Footer />,
+      {},
+    );
+
+    expect(getAllByRole('link')).toHaveLength(4);
+    expect(getAllByTestId('GitHubIcon')).toHaveLength(3);
+    expect(getByText('2023 Lazy Uploads RS School Team')).toBeInTheDocument();
+  });
+
+  it('should have dark logo with default theme', () => {
+    const { getByTestId, queryByTestId } = customRender(<Footer />, {});
+
+    expect(getByTestId('rslogo_dark')).toBeInTheDocument();
+    expect(queryByTestId('rslogo_light')).toBeNull();
+  });
+
+  it('should have light logo with dark theme', () => {
+    const { getByTestId, queryByTestId } = customRender(<Footer />, {
+      colorMode: 'dark',
+    });
+
+    expect(getByTestId('rslogo_light')).toBeInTheDocument();
+    expect(queryByTestId('rslogo_dark')).toBeNull();
+  });
+});

--- a/src/components/RsLogo/RsLogo.tsx
+++ b/src/components/RsLogo/RsLogo.tsx
@@ -17,12 +17,14 @@ const RsLogo = memo(({ height = '24px' }: Props) => {
       src="rs_school_js_lighter.svg"
       alt="RS School Logo"
       height={height}
+      data-testid={'rslogo_light'}
     />
   ) : (
     <RsLogoStyled
       src="rs_school_js_darker.svg"
       alt="RS School Logo"
       height={height}
+      data-testid={'rslogo_dark'}
     />
   );
 });

--- a/src/store/reducers/userSlice.ts
+++ b/src/store/reducers/userSlice.ts
@@ -1,7 +1,7 @@
 import { User } from '@/types/user';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-type UserState = {
+export type UserState = {
   user: User | null;
 };
 

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,4 +1,4 @@
-import { configureStore, ThunkAction, Action } from '@reduxjs/toolkit';
+import { configureStore } from '@reduxjs/toolkit';
 import userReducer from './reducers/userSlice';
 
 export const store = configureStore({
@@ -9,9 +9,4 @@ export const store = configureStore({
 
 export type AppDispatch = typeof store.dispatch;
 export type RootState = ReturnType<typeof store.getState>;
-export type AppThunk<ReturnType = void> = ThunkAction<
-  ReturnType,
-  RootState,
-  unknown,
-  Action<string>
->;
+export type AppStore = typeof store;

--- a/src/test/__mocks__/mockStore.ts
+++ b/src/test/__mocks__/mockStore.ts
@@ -1,0 +1,10 @@
+import { PreloadedState } from '@reduxjs/toolkit';
+import { RootState } from '@/store/store';
+
+export const initialState: PreloadedState<RootState> = {
+  user: { user: null },
+};
+
+export const stateWithUser: PreloadedState<RootState> = {
+  user: { user: { email: 'test@test.com', id: 'some_id' } },
+};

--- a/src/test/providers/customRender.tsx
+++ b/src/test/providers/customRender.tsx
@@ -1,0 +1,73 @@
+import { PropsWithChildren, ReactElement } from 'react';
+import { render, RenderOptions, RenderResult } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore, PreloadedState } from '@reduxjs/toolkit';
+import { createTheme, ThemeProvider } from '@mui/material';
+import { BrowserRouter } from 'react-router-dom';
+import { AppStore, RootState } from '@/store/store';
+import userReducer from '@/store/reducers/userSlice';
+import { LanguageContext } from '@/components/context/LanguageContext/LanguageContext';
+import { ColorModeContext } from '@/components/context/ColorModeContext/ColorModeContext';
+import { Langs } from '@/constants/dictionaries';
+import { RoutePaths } from '@/routes/routes';
+import { initialState } from '@/test/__mocks__/mockStore';
+
+interface CustomRenderProps extends RenderOptions {
+  language?: Langs;
+  setLanguage?: (newLanguage: Langs) => void;
+  colorMode?: 'light' | 'dark';
+  toggleColorMode?: VoidFunction;
+  preloadedState?: PreloadedState<RootState>;
+  store?: AppStore;
+  route?: string;
+}
+
+interface RenderResultWithStore extends RenderResult {
+  store: AppStore;
+}
+
+export const customRender = (
+  ui: ReactElement,
+  {
+    language = Langs.EN,
+    setLanguage = () => {},
+    colorMode = 'light',
+    toggleColorMode = () => {},
+    preloadedState = initialState,
+    store = configureStore({
+      reducer: {
+        user: userReducer,
+      },
+      preloadedState,
+    }) as AppStore,
+    route = RoutePaths.IndexPage,
+    ...renderOptions
+  }: CustomRenderProps,
+): RenderResultWithStore => {
+  window.history.pushState({}, 'Test page', route);
+
+  const wrapper = ({ children }: PropsWithChildren): ReactElement => (
+    <Provider store={store}>
+      <BrowserRouter>
+        <LanguageContext.Provider value={{ language, setLanguage }}>
+          <ColorModeContext.Provider value={{ toggleColorMode }}>
+            <ThemeProvider
+              theme={createTheme({
+                palette: {
+                  mode: colorMode,
+                },
+              })}
+            >
+              {children}
+            </ThemeProvider>
+          </ColorModeContext.Provider>
+        </LanguageContext.Provider>
+      </BrowserRouter>
+    </Provider>
+  );
+
+  return {
+    store,
+    ...(render(ui, { wrapper, ...renderOptions }) as RenderResult),
+  };
+};


### PR DESCRIPTION
resolve #22, #38 

Add customRender for tests, which extends render method of  testing-library and wrap component that is testing with:
- store provider, 
- Router,
- Language Context,
- ColorMode Context,
- ThemeProvider.

Add some userReducer's and Footer's tests cases.